### PR TITLE
Fixing plots in each chapter

### DIFF
--- a/R/render_markdowns.R
+++ b/R/render_markdowns.R
@@ -2,17 +2,17 @@
 rmarkdown_file <- "parameterised_report.Rmd"
 
 # the parameter we're going to pass to the report
-years <- c(2010:2020)
+report_cyl <- c(4, 6, 8)
 
 # Run Parameterised Reports ----------------------------------------------------
-# run through the years and render each version of the report.
+# run through the cyls and render each version of the report.
 # the important part here is "run_pandoc = FALSE" which will leave us with
 # a .md file for each report.
 markdowns <- lapply(
-  years,
+  report_cyl,
   function(x, filename){
 
-    rmarkdown::render(filename, params = list(year = x), run_pandoc = FALSE)
+    rmarkdown::render(filename, params = list(cyl_num = x), run_pandoc = FALSE)
 
     base_filename <- xfun::sans_ext(filename)
     # filename.knit.md will be created by the render

--- a/R/render_markdowns.R
+++ b/R/render_markdowns.R
@@ -1,5 +1,5 @@
 # name of the parameterised report rmarkdown
-rmarkdown_file <- "parameterised_report.Rmd"
+rmarkdown_file <- "parameterised_report"
 
 # the parameter we're going to pass to the report
 report_cyl <- c(4, 6, 8)
@@ -11,14 +11,24 @@ report_cyl <- c(4, 6, 8)
 markdowns <- lapply(
   report_cyl,
   function(x, filename){
+    # this folder will hold our report files - the images for plots etc.
+    output_files <- paste(filename, x, sep = "_")
 
-    rmarkdown::render(filename, params = list(cyl_num = x), run_pandoc = FALSE)
+    # name of the underlying, parameterised report to render for each chapter
+    rmd_filename <- xfun::with_ext(filename, ".Rmd")
 
-    base_filename <- xfun::sans_ext(filename)
+    # render markdown
+    # this will create a file called filename.knit.md but the report files will
+    # be put in a folder called *output_files*_files
+    rmarkdown::render(
+      rmd_filename, output_file = output_files,
+      params = list(cyl_num = x), run_pandoc = FALSE
+    )
+
     # filename.knit.md will be created by the render
-    knit_file <- xfun::with_ext(filename, ".knit.md")
+    knit_file <- xfun::with_ext(rmd_filename, ".knit.md")
     # to avoid saving over it each time, rename it
-    new_file_name <- xfun::with_ext(paste0(base_filename, "_", x), ".knit.md")
+    new_file_name <- xfun::with_ext(output_files, ".knit.md")
     file.rename(knit_file, new_file_name)
 
     # return our new file name
@@ -32,7 +42,7 @@ markdowns <- lapply(
 # do the same for the index file
 index_file <- "index.Rmd"
 rmarkdown::render(index_file, run_pandoc = FALSE)
-index_file <- xfun::with_ext(xfun::sans_ext(index_file), ".knit.md")
+index_file <- xfun::with_ext(index_file, ".knit.md")
 
 # add the index file to the list of other markdowns
 markdowns <- append(index_file, markdowns)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 README
 
 Run `run.R` to generate a book from `parameterised_report.Rmd` with an `index.Rmd` 
-and one `child_document.Rmd`. Only packages needed are `xfun` and `rmarkdown`.
+and one `child_document.Rmd`. Only packages needed are `xfun`, `rmarkdown` and `bookdown`.

--- a/index.Rmd
+++ b/index.Rmd
@@ -1,6 +1,6 @@
 --- 
 title: "Book Example"
-author: "Zachary Waller"
+author: "Original by Zachary Waller, breakage by Morgan Grovenburg"
 output: bookdown::gitbook
 documentclass: book
 description: "This is a minimal example of turning a parameterised rmarkdown report into a book."
@@ -13,8 +13,4 @@ The idea is to render the parameterised report into `.md` files, which will fill
 the parameters in and generate images, but keep the files in plan text format.
 
 These reports then get pasted together (with the `index` file at the start) and 
-rendered into one book. This approach is a little hacky (I largely just took 
-snippets of code from the bookdown source) and doesn't do much fancy stuff (it 
-doesn't quite put files in the right place), but hopefully it'll be helpful to 
-someone!
-
+rendered into one book. 

--- a/parameterised_report.Rmd
+++ b/parameterised_report.Rmd
@@ -1,14 +1,18 @@
 ---
 output: html_document
 params:
-  year: NA
-title: "Document for Year: `r params$year`"
+  cyl_num: 4
+title: "Example"
 ---
 
-# Chapter: `r params$year`
+# Chapter: `r params$cyl_num` cyl
 
-This is a very simple document that jsut uses one parameter.
-The year is `r params$year`.
+Does the plot below show `r params$cyl_num` cyl?
 
-```{r child = if(params$year == 2011){"child_document.Rmd"} }
+```{r}
+library(tidyverse)
+mtcars %>%
+filter(cyl == params$cyl_num) %>%
+ggplot(aes(x = cyl, mpg)) +
+geom_point()
 ```

--- a/run.R
+++ b/run.R
@@ -1,4 +1,5 @@
 library(xfun)
 library(rmarkdown)
+library(tidyverse)
 
 source("R/render_markdowns.R")

--- a/run.R
+++ b/run.R
@@ -1,5 +1,6 @@
 library(xfun)
 library(rmarkdown)
+library(bookdown)
 library(tidyverse)
 
 source("R/render_markdowns.R")


### PR DESCRIPTION
To fix #1, noticed by [morganlig](https://github.com/morganlig), where report files would overwrite between each chapter, resulting in only the last plot, say, being rendered in each chapter, even if the plots should be different. 

The issue was just due to each chapter writing to the same folder so the solution is to use the intermediate `.knit.md` filename (with parameters in the filename) to write report files to. 

In Morgan's example [here](https://github.com/morganlig/parameterised_bookdown) plots were getting saved to `parameterised_report_files/` with plots being named something like `untitled-chunk-1-1.png` by every chapter (i.e. plots were overwritten by subsequent chapters' plots) - resulting in the `cyl == 8` plot appearing in each chapter. The fix changes the names of the document file folders so they're all different: `parameterised_report_4_files/`,  `parameterised_report_6_files/` ....

I should probably do something to give a cleaner folder structure as I can see the number of document file folders getting a bit messy for large reports.